### PR TITLE
⏪️ Revert "🧑‍💻 Add renovate support for bumping paper-api"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,15 +20,6 @@
       "groupName": "kotest"
     },
     {
-      "matchDatasources": [
-        "maven"
-      ],
-      "matchPackageNames": [
-        "io.papermc.paper:paper-api"
-      ],
-      "versioning": "regex:^(?<major>(?:\\d|\\.)+)-(?<compatibility>R(?:\\d|\\.)+)-(?:\\d+)\\.(?:\\d+)-(?<minor>\\d+)"
-    },
-    {
       "matchUpdateTypes": [
         "minor",
         "patch"


### PR DESCRIPTION
This reverts commit 95c306c5c52330865bd0cfa3ae4a960d8951a401.