### PR TITLE
🧑‍💻 Make MockPaper as singleton

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,6 @@ tasks {
 
     withType<Test> {
         useJUnitPlatform()
-//        maxParallelForks = Runtime.getRuntime().availableProcessors() / 2 + 1
 
         extensions.configure<KoverTaskExtension> {
             isDisabled = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ tasks {
 
     withType<Test> {
         useJUnitPlatform()
-        maxParallelForks = Runtime.getRuntime().availableProcessors() / 2 + 1
+//        maxParallelForks = Runtime.getRuntime().availableProcessors() / 2 + 1
 
         extensions.configure<KoverTaskExtension> {
             isDisabled = false

--- a/src/main/kotlin/land/vani/mockpaper/MockPaper.kt
+++ b/src/main/kotlin/land/vani/mockpaper/MockPaper.kt
@@ -1,15 +1,57 @@
 package land.vani.mockpaper
 
 import org.bukkit.Bukkit
+import java.util.logging.Level
 
 object MockPaper {
     @JvmStatic
-    @JvmOverloads
-    fun mock(implementation: ServerMock = ServerMock()): ServerMock {
-        @Suppress("SENSELESS_COMPARISON")
-        if (Bukkit.getServer() == null) {
-            Bukkit.setServer(implementation)
+    var mock: ServerMock?
+        get() = Bukkit.getServer() as ServerMock?
+        private set(value) {
+            if (value != null) {
+                val defaultLevel = value.logger.level
+                value.logger.level = Level.WARNING
+                Bukkit.setServer(value)
+                value.logger.level = defaultLevel
+            } else {
+                val serverProperty = Bukkit::class.java.getDeclaredField("server").apply {
+                    isAccessible = true
+                }
+                serverProperty[null] = null
+            }
         }
-        return implementation
+
+    @JvmStatic
+    fun mock(): ServerMock = mock(ServerMock())
+
+    @JvmStatic
+    fun <T : ServerMock> mock(implementation: T): T {
+        @Suppress("SENSELESS_COMPARISON")
+        check(Bukkit.getServer() == null && mock == null) {
+            "ServerMock is already initialized." +
+                " If you want to re-mock with another implementation, please unmock first."
+        }
+
+        return implementation.also {
+            mock = it
+        }
+    }
+
+    @JvmStatic
+    fun unmock() {
+        val mock = this.mock ?: run {
+            println("unmock is requested but mock is null")
+            return
+        }
+
+        mock.pluginManager.disablePlugins()
+
+        try {
+            mock.scheduler.shutdown()
+        } finally {
+            mock.pluginManager.deleteTemporaryPaths()
+        }
+
+        this.mock = null
     }
 }

--- a/src/test/kotlin/land/vani/mockpaper/BanListTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/BanListTest.kt
@@ -11,7 +11,7 @@ import java.util.Date
 class BanListTest : ShouldSpec({
     lateinit var banList: BanListMock
 
-    beforeTest {
+    beforeEach {
         banList = BanListMock()
     }
 

--- a/src/test/kotlin/land/vani/mockpaper/ServerTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/ServerTest.kt
@@ -40,8 +40,12 @@ import java.util.UUID
 class ServerTest : ShouldSpec({
     lateinit var server: ServerMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("getOnlinePlayers") {

--- a/src/test/kotlin/land/vani/mockpaper/UnsafeValuesTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/UnsafeValuesTest.kt
@@ -9,10 +9,14 @@ class UnsafeValuesTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var unsafeValues: UnsafeValuesMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         @Suppress("DEPRECATION")
         unsafeValues = server.unsafe
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     val pluginInfoFormat = """

--- a/src/test/kotlin/land/vani/mockpaper/block/BlockTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/BlockTest.kt
@@ -23,6 +23,10 @@ class BlockTest : ShouldSpec({
         block = BlockMock(randomLocation(world))
     }
 
+    afterEach {
+        MockPaper.unmock()
+    }
+
     should("type default is air") {
         block.type shouldBe Material.AIR
     }

--- a/src/test/kotlin/land/vani/mockpaper/block/state/BarrelTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/BarrelTest.kt
@@ -18,8 +18,12 @@ import org.bukkit.loot.LootTables
 class BarrelTest : ShouldSpec({
     lateinit var server: ServerMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("placed") {
@@ -27,7 +31,7 @@ class BarrelTest : ShouldSpec({
         lateinit var block: BlockMock
         lateinit var barrel: BarrelMock
 
-        beforeTest {
+        beforeEach {
             world = WorldMock(server)
             block = BlockMock(Material.BARREL, randomLocation(world))
             barrel = BarrelMock(Material.BARREL, block)
@@ -52,7 +56,7 @@ class BarrelTest : ShouldSpec({
     context("not placed") {
         lateinit var barrel: BarrelMock
 
-        beforeTest {
+        beforeEach {
             barrel = BarrelMock(Material.BARREL)
         }
 
@@ -80,7 +84,7 @@ class BarrelTest : ShouldSpec({
     context("common") {
         lateinit var barrel: BarrelMock
 
-        beforeTest {
+        beforeEach {
             barrel = BarrelMock(Material.BARREL)
         }
 

--- a/src/test/kotlin/land/vani/mockpaper/block/state/BlockStateTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/BlockStateTest.kt
@@ -16,8 +16,12 @@ import org.bukkit.Material
 class BlockStateTest : ShouldSpec({
     lateinit var server: ServerMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("constructor") {
@@ -43,7 +47,7 @@ class BlockStateTest : ShouldSpec({
         lateinit var location: Location
         lateinit var block: BlockMock
         lateinit var state: BlockStateMock
-        beforeTest {
+        beforeEach {
             location = randomLocation(server.addSimpleWorld("test"))
             block = BlockMock(Material.DIRT, location)
             state = block.state
@@ -93,7 +97,7 @@ class BlockStateTest : ShouldSpec({
 
     context("not placed") {
         lateinit var state: BlockStateMock
-        beforeTest {
+        beforeEach {
             state = BlockStateMock(Material.DIRT)
         }
 

--- a/src/test/kotlin/land/vani/mockpaper/block/state/ChestTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/ChestTest.kt
@@ -18,9 +18,13 @@ import java.util.UUID
 class ChestTest : ShouldSpec({
     lateinit var chest: ChestMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         chest = ChestMock(Material.CHEST)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("setLock") {

--- a/src/test/kotlin/land/vani/mockpaper/block/state/DispenserTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/DispenserTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.nulls.shouldBeNull
+import land.vani.mockpaper.MockPaper
 import land.vani.mockpaper.UnimplementedOperationException
 import org.bukkit.Material
 import org.bukkit.loot.LootTables
@@ -12,8 +13,13 @@ import java.util.UUID
 class DispenserTest : ShouldSpec({
     lateinit var dispenser: DispenserMock
 
-    beforeTest {
+    beforeEach {
+        MockPaper.mock()
         dispenser = DispenserMock(Material.DISPENSER)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("getLootTable is not implemented yet") {

--- a/src/test/kotlin/land/vani/mockpaper/block/state/DropperTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/DropperTest.kt
@@ -3,6 +3,7 @@ package land.vani.mockpaper.block.state
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.ShouldSpec
+import land.vani.mockpaper.MockPaper
 import land.vani.mockpaper.UnimplementedOperationException
 import org.bukkit.Material
 import org.bukkit.loot.LootTables
@@ -11,8 +12,13 @@ import java.util.UUID
 class DropperTest : ShouldSpec({
     lateinit var dispenser: DropperMock
 
-    beforeTest {
+    beforeEach {
+        MockPaper.mock()
         dispenser = DropperMock(Material.DROPPER)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("getLootTable is not implemented yet") {

--- a/src/test/kotlin/land/vani/mockpaper/block/state/EnderChestTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/EnderChestTest.kt
@@ -9,7 +9,7 @@ import org.bukkit.Material
 class EnderChestTest : ShouldSpec({
     lateinit var enderChest: EnderChestMock
 
-    beforeTest {
+    beforeEach {
         enderChest = EnderChestMock(Material.ENDER_CHEST)
     }
 

--- a/src/test/kotlin/land/vani/mockpaper/block/state/HopperTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/HopperTest.kt
@@ -18,9 +18,13 @@ import java.util.UUID
 class HopperTest : ShouldSpec({
     lateinit var hopper: HopperMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         hopper = HopperMock(Material.HOPPER)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("setLock") {

--- a/src/test/kotlin/land/vani/mockpaper/block/state/LecternTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/LecternTest.kt
@@ -15,9 +15,13 @@ import org.bukkit.inventory.meta.BookMeta
 class LecternTest : ShouldSpec({
     lateinit var lectern: LecternMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         lectern = LecternMock(Material.LECTERN)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("setPage is valid") {

--- a/src/test/kotlin/land/vani/mockpaper/block/state/ShulkerBoxTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/ShulkerBoxTest.kt
@@ -33,9 +33,13 @@ private fun Arb.Companion.notShulkerBox(): Arb<Material> = Arb.enum<Material>()
 class ShulkerBoxTest : ShouldSpec({
     lateinit var shulkerBox: ShulkerBoxMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         shulkerBox = ShulkerBoxMock(Material.SHULKER_BOX)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("material block state") {

--- a/src/test/kotlin/land/vani/mockpaper/block/state/SignTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/block/state/SignTest.kt
@@ -15,7 +15,7 @@ import org.bukkit.Material
 class SignTest : ShouldSpec({
     lateinit var sign: SignMock
 
-    beforeTest {
+    beforeEach {
         sign = SignMock(Material.OAK_SIGN)
     }
 

--- a/src/test/kotlin/land/vani/mockpaper/boss/BossBarTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/boss/BossBarTest.kt
@@ -29,6 +29,10 @@ class BossBarTest : ShouldSpec({
         )
     }
 
+    afterEach {
+        MockPaper.unmock()
+    }
+
     should("flags is correct") {
         bar.hasFlag(BarFlag.PLAY_BOSS_MUSIC) shouldBe true
         bar.hasFlag(BarFlag.CREATE_FOG) shouldBe true

--- a/src/test/kotlin/land/vani/mockpaper/boss/KeyedBossBarTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/boss/KeyedBossBarTest.kt
@@ -18,6 +18,10 @@ class KeyedBossBarTest : ShouldSpec({
         server = MockPaper.mock()
     }
 
+    afterEach {
+        MockPaper.unmock()
+    }
+
     should("keyedBossBar") {
         @Suppress("DEPRECATION")
         val key = NamespacedKey("mockpaper", "bossbar1")

--- a/src/test/kotlin/land/vani/mockpaper/command/PlayerMessageTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/command/PlayerMessageTest.kt
@@ -21,6 +21,10 @@ class PlayerMessageTest : ShouldSpec({
         player = server.addPlayer()
     }
 
+    afterEach {
+        MockPaper.unmock()
+    }
+
     should("sendMessage(Component)") {
         player.sendMessage(
             Component.text("Component message").color(NamedTextColor.WHITE)

--- a/src/test/kotlin/land/vani/mockpaper/entity/ArmorStandTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/entity/ArmorStandTest.kt
@@ -15,10 +15,14 @@ class ArmorStandTest : ShouldSpec({
     lateinit var world: WorldMock
     lateinit var armorStand: ArmorStandMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         world = server.addSimpleWorld("world")
         armorStand = world.spawn(randomLocation(world))
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("entityType") {

--- a/src/test/kotlin/land/vani/mockpaper/entity/EntityEquipmentTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/entity/EntityEquipmentTest.kt
@@ -16,10 +16,14 @@ class EntityEquipmentTest : ShouldSpec({
     lateinit var armorStand: ArmorStandMock
     lateinit var equipment: EntityEquipment
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         armorStand = ArmorStandMock(server, UUID.randomUUID())
         equipment = armorStand.equipment
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("mainHand") {

--- a/src/test/kotlin/land/vani/mockpaper/entity/EntityTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/entity/EntityTest.kt
@@ -34,10 +34,14 @@ class EntityTest : ShouldSpec({
     lateinit var world: WorldMock
     lateinit var entity: EntityMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         world = server.addSimpleWorld("world")
         entity = SimpleEntityMock(server)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("server") {

--- a/src/test/kotlin/land/vani/mockpaper/entity/ExperienceOrbTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/entity/ExperienceOrbTest.kt
@@ -16,10 +16,14 @@ class ExperienceOrbTest : ShouldSpec({
     lateinit var world: WorldMock
     lateinit var orb: ExperienceOrbMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         world = server.addSimpleWorld("world")
         orb = world.spawn(randomLocation(world))
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("entityType") {

--- a/src/test/kotlin/land/vani/mockpaper/entity/FireworkTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/entity/FireworkTest.kt
@@ -20,10 +20,14 @@ class FireworkTest : ShouldSpec({
     lateinit var world: WorldMock
     lateinit var firework: FireworkMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         world = server.addSimpleWorld("world")
         firework = world.spawn(randomLocation(world))
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("entityType") {

--- a/src/test/kotlin/land/vani/mockpaper/entity/ItemTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/entity/ItemTest.kt
@@ -22,9 +22,13 @@ class ItemTest : ShouldSpec({
     var item = ItemStack(Material.EMERALD)
     lateinit var entity: Item
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         world = server.addSimpleWorld("world")
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("entityType") {

--- a/src/test/kotlin/land/vani/mockpaper/help/HelpMapTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/help/HelpMapTest.kt
@@ -13,9 +13,13 @@ class HelpMapTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var helpMap: HelpMapMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         helpMap = server.helpMap
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("lookup") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/InventoryTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/InventoryTest.kt
@@ -16,9 +16,13 @@ import org.bukkit.inventory.ItemStack
 class InventoryTest : ShouldSpec({
     lateinit var inventory: InventoryMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         inventory = InventoryMock(null, 9, InventoryType.CHEST)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("constructors") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/InventoryViewTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/InventoryViewTest.kt
@@ -10,7 +10,7 @@ class InventoryViewTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var view: InventoryViewMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         view = InventoryViewMock(
             server.addPlayer(),
@@ -18,6 +18,10 @@ class InventoryViewTest : ShouldSpec({
             server.createInventory(null, InventoryType.CHEST),
             InventoryType.CHEST
         )
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("constructor") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/ItemFactoryTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/ItemFactoryTest.kt
@@ -23,9 +23,13 @@ class ItemFactoryTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var factory: ItemFactoryMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         factory = server.itemFactory as ItemFactoryMock
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("getItemMeta") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/PlayerInventoryTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/PlayerInventoryTest.kt
@@ -19,9 +19,13 @@ class PlayerInventoryTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var inventory: PlayerInventoryMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         inventory = PlayerInventoryMock(null)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("inventory size is 41") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/PlayerInventoryViewTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/PlayerInventoryViewTest.kt
@@ -9,8 +9,12 @@ import org.bukkit.event.inventory.InventoryType
 class PlayerInventoryViewTest : ShouldSpec({
     lateinit var server: ServerMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("constructor") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/BookMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/BookMetaTest.kt
@@ -13,9 +13,13 @@ import org.bukkit.inventory.meta.BookMeta
 class BookMetaTest : ShouldSpec({
     lateinit var meta: BookMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = BookMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("constructor") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/EnchantedBootMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/EnchantedBootMetaTest.kt
@@ -13,11 +13,15 @@ class EnchantedBootMetaTest : ShouldSpec({
 
     lateinit var meta: EnchantedBookMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = EnchantedBookMetaMock()
         enchantment1 = Enchantment.DURABILITY
         enchantment2 = Enchantment.DAMAGE_ALL
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("enchants") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/FireworkEffectMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/FireworkEffectMetaTest.kt
@@ -9,9 +9,13 @@ import org.bukkit.FireworkEffect
 class FireworkEffectMetaTest : ShouldSpec({
     lateinit var meta: FireworkEffectMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = FireworkEffectMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("hasEffect is default false") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/FireworkMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/FireworkMetaTest.kt
@@ -12,9 +12,13 @@ import org.bukkit.FireworkEffect
 class FireworkMetaTest : ShouldSpec({
     lateinit var meta: FireworkMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = FireworkMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("addEffect") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/ItemMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/ItemMetaTest.kt
@@ -23,9 +23,13 @@ import java.io.ByteArrayOutputStream
 class ItemMetaTest : ShouldSpec({
     lateinit var meta: ItemMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = ItemMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("constructor") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/KnowledgeBookMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/KnowledgeBookMetaTest.kt
@@ -9,9 +9,13 @@ import org.bukkit.Material
 class KnowledgeBookMetaTest : ShouldSpec({
     lateinit var meta: KnowledgeBookMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = KnowledgeBookMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("hasRecipes is default false") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/LeatherArmorMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/LeatherArmorMetaTest.kt
@@ -10,9 +10,13 @@ class LeatherArmorMetaTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var meta: LeatherArmorMetaMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         meta = LeatherArmorMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("getColor is default") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/PotionMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/PotionMetaTest.kt
@@ -15,9 +15,13 @@ import org.bukkit.potion.PotionType
 class PotionMetaTest : ShouldSpec({
     lateinit var meta: PotionMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = PotionMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("basePotionData") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/SkullMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/SkullMetaTest.kt
@@ -8,9 +8,13 @@ import land.vani.mockpaper.MockPaper
 class SkullMetaTest : ShouldSpec({
     lateinit var meta: SkullMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = SkullMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("owner") {

--- a/src/test/kotlin/land/vani/mockpaper/inventory/meta/SuspiciousStewMetaTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/inventory/meta/SuspiciousStewMetaTest.kt
@@ -12,9 +12,13 @@ import org.bukkit.potion.PotionEffectType
 class SuspiciousStewMetaTest : ShouldSpec({
     lateinit var meta: SuspiciousStewMetaMock
 
-    beforeTest {
+    beforeEach {
         MockPaper.mock()
         meta = SuspiciousStewMetaMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("customEffect") {

--- a/src/test/kotlin/land/vani/mockpaper/metadata/MetadataHolderTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/metadata/MetadataHolderTest.kt
@@ -12,9 +12,13 @@ class MetadataHolderTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var meta: MetadataHolder
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         meta = MetadataHolder()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("setMetadata") {

--- a/src/test/kotlin/land/vani/mockpaper/persistence/PersistentDataTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/persistence/PersistentDataTest.kt
@@ -18,9 +18,13 @@ class PersistentDataTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var container: PersistentDataContainerMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         container = PersistentDataContainerMock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("adapterContext") {

--- a/src/test/kotlin/land/vani/mockpaper/player/OfflinePlayerTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/player/OfflinePlayerTest.kt
@@ -10,8 +10,12 @@ import java.util.UUID
 class OfflinePlayerTest : ShouldSpec({
     lateinit var server: ServerMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("isOnline") {

--- a/src/test/kotlin/land/vani/mockpaper/player/PlayerTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/player/PlayerTest.kt
@@ -55,7 +55,7 @@ class PlayerTest : ShouldSpec({
     lateinit var uuid: UUID
     lateinit var player: PlayerMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock(
             object : ServerMock() {
                 private var tick = 0
@@ -66,6 +66,10 @@ class PlayerTest : ShouldSpec({
         )
         uuid = UUID.randomUUID()
         player = PlayerMock(server, randomPlayerName(), uuid)
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("entityType is Player") {

--- a/src/test/kotlin/land/vani/mockpaper/plugin/PluginManagerTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/plugin/PluginManagerTest.kt
@@ -21,10 +21,14 @@ class PluginManagerTest : ShouldSpec({
     lateinit var pluginManager: PluginManagerMock
     lateinit var plugin: MockPlugin
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         pluginManager = server.pluginManager
         plugin = pluginManager.createMockPlugin("MockPlugin")
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("getPlugin(String)") {

--- a/src/test/kotlin/land/vani/mockpaper/scheduler/BukkitSchedulerTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/scheduler/BukkitSchedulerTest.kt
@@ -17,10 +17,14 @@ class BukkitSchedulerTest : ShouldSpec({
     lateinit var scheduler: BukkitSchedulerMock
     lateinit var plugin: MockPlugin
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         scheduler = BukkitSchedulerMock(server)
         plugin = server.pluginManager.createMockPlugin()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("currentTick") {

--- a/src/test/kotlin/land/vani/mockpaper/scheduler/RepeatedTaskTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/scheduler/RepeatedTaskTest.kt
@@ -10,9 +10,13 @@ class RepeatedTaskTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var plugin: MockPlugin
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         plugin = server.pluginManager.createMockPlugin()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("scheduledTick on start is delay") {

--- a/src/test/kotlin/land/vani/mockpaper/scheduler/ScheduledTaskTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/scheduler/ScheduledTaskTest.kt
@@ -14,9 +14,13 @@ class ScheduledTaskTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var plugin: MockPlugin
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         plugin = server.pluginManager.createMockPlugin()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("scheduled tick") {

--- a/src/test/kotlin/land/vani/mockpaper/statistic/StatisticTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/statistic/StatisticTest.kt
@@ -15,9 +15,13 @@ class StatisticTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var player: PlayerMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         player = server.addPlayer()
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     should("defaults") {

--- a/src/test/kotlin/land/vani/mockpaper/world/CoordinateTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/world/CoordinateTest.kt
@@ -8,7 +8,7 @@ import land.vani.mockpaper.randomCoordinate
 class CoordinateTest : ShouldSpec({
     lateinit var coordinate: Coordinate
 
-    beforeTest {
+    beforeEach {
         coordinate = randomCoordinate()
     }
 

--- a/src/test/kotlin/land/vani/mockpaper/world/WorldTest.kt
+++ b/src/test/kotlin/land/vani/mockpaper/world/WorldTest.kt
@@ -23,9 +23,13 @@ class WorldTest : ShouldSpec({
     lateinit var server: ServerMock
     lateinit var world: WorldMock
 
-    beforeTest {
+    beforeEach {
         server = MockPaper.mock()
         world = server.addWorld(WorldMock(server))
+    }
+
+    afterEach {
+        MockPaper.unmock()
     }
 
     context("name") {


### PR DESCRIPTION
This Pull Request will ensure that the `ServerMock` provided by MockPaper is guaranteed to have only one instance per test.

# Overview
In the Bukkit API, the `Server` implementation is assumed to have only one instance.

MockPaper has so far ignored that assumption and aimed for fast test completion by allowing parallel execution of tests, but we have found that there are some inconvenient cases.

Therefore, we have decided to drop this policy and instead perform instance creation at test start and instance destruction at test end.

***Note***:  the responsibility of the test writer to destroy the `ServerMock` instance at the end of the test.

# Examples (with JUnit5)

```java
ServerMock mock;

@BeforeEach
void setup() {
    mock = MockPaper.mock()
}

@AfterEach
void teardown() {
    MockPaper.unmock()
}
```